### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     ports:
      - "8080:8080"
     environment:
-      TR_DB_HOST: mysql
+      TR_DB_HOST: db
     depends_on:
       - db
   db:


### PR DESCRIPTION
fix mysql host

```
traduora_1  | [Nest] 1   - 3/11/2019, 10:36:30 AM   [ExceptionHandler] getaddrinfo ENOTFOUND mysql mysql:3306 +2ms
traduora_1  | Error: getaddrinfo ENOTFOUND mysql mysql:3306
traduora_1  |     at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:57:26)
traduora_1  |     --------------------
traduora_1  |     at Protocol._enqueue (/opt/traduora/node_modules/mysql/lib/protocol/Protocol.js:144:48)
traduora_1  |     at Protocol.handshake (/opt/traduora/node_modules/mysql/lib/protocol/Protocol.js:51:23)
traduora_1  |     at PoolConnection.connect (/opt/traduora/node_modules/mysql/lib/Connection.js:118:18)
traduora_1  |     at Pool.getConnection (/opt/traduora/node_modules/mysql/lib/Pool.js:48:16)
traduora_1  |     at /opt/traduora/node_modules/typeorm/driver/mysql/MysqlDriver.js:700:18
traduora_1  |     at new Promise (<anonymous>)
traduora_1  |     at MysqlDriver.createPool (/opt/traduora/node_modules/typeorm/driver/mysql/MysqlDriver.js:697:16)
traduora_1  |     at MysqlDriver.<anonymous> (/opt/traduora/node_modules/typeorm/driver/mysql/MysqlDriver.js:253:51)
traduora_1  |     at step (/opt/traduora/node_modules/typeorm/driver/mysql/MysqlDriver.js:32:23)
traduora_1  |     at Object.next (/opt/traduora/node_modules/typeorm/driver/mysql/MysqlDriver.js:13:53)
traduora_traduora_1 exited with code 139
````