### PR TITLE
Set default MySQL charset to utf8mb4

### DIFF
--- a/api/ormconfig.yaml
+++ b/api/ormconfig.yaml
@@ -1,3 +1,6 @@
+# NOTE: this config is only used for the typeorm cli on development.
+# For the config used by the API, checkout api/src/config.ts and the environment variables documentation.
+
 default:
   type: mysql
   host: localhost
@@ -9,6 +12,7 @@ default:
   logging: true
   entities: ['src/entity/*.entity.ts']
   migrations: ['src/migrations/*.ts']
+  charset: utf8mb4
   cli:
     entitiesDir: src/entity
     migrationsDir: src/migrations

--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -39,6 +39,7 @@ export const config = {
       username: env.TR_DB_USER || 'root',
       password: env.TR_DB_PASSWORD || '',
       database: env.TR_DB_DATABASE || 'tr_dev',
+      charset: 'utf8mb4',
       synchronize: false,
       logging: false,
       entities: ['src/entity/*.entity*'],

--- a/api/src/migrations/1552729314169-set-default-encoding.ts
+++ b/api/src/migrations/1552729314169-set-default-encoding.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class setDefaultEncoding1552729314169 implements MigrationInterface {
+  tables = ['migrations', 'project_locale', 'translation', 'project_client', 'term', 'project_user', 'plan', 'project', 'user', 'locale'];
+
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query('SET FOREIGN_KEY_CHECKS=0;');
+    for (const table of this.tables) {
+      await queryRunner.query(`ALTER TABLE \`${table}\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;`);
+    }
+    await queryRunner.query('SET FOREIGN_KEY_CHECKS=1;');
+  }
+
+  // No down migration since we cannot guess what the previous default encoding was
+  public async down(queryRunner: QueryRunner): Promise<any> {}
+}

--- a/api/test/export.e2e-spec.ts
+++ b/api/test/export.e2e-spec.ts
@@ -2,6 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import './util';
 import { createAndMigrateApp, createTestProject, signupTestUser, TestingProject, TestingUser } from './util';
+import { propertiesParser } from '../src/formatters/properties';
 
 describe('ExportController (e2e)', () => {
   let app: INestApplication;
@@ -90,7 +91,7 @@ describe('ExportController (e2e)', () => {
         .set('Authorization', `Bearer ${testingUser.accessToken}`)
         .send({
           termId: termTwoId,
-          value: 'deux',
+          value: 'deux ⛄ 😀👍 🍉你好',
         })
         .expect(200);
     }
@@ -106,6 +107,32 @@ describe('ExportController (e2e)', () => {
         expect(Object.keys(parsed)).toHaveLength(2);
         expect(parsed['term.two']).toEqual('zwei');
         expect(parsed['term.one']).toEqual('eins');
+      });
+  });
+
+  it('/api/v1/projects/:projectId/exports (GET) should export translation with utf-8 characters in various formats', async () => {
+    await request(app.getHttpServer())
+      .get(`/api/v1/projects/${testProject.id}/exports?locale=fr&format=jsonflat`)
+      .set('Authorization', `Bearer ${testingUser.accessToken}`)
+      .expect(200)
+      .expect(res => {
+        const parsed = JSON.parse(Buffer.from(res.body).toString('utf-8'));
+        expect(Object.keys(parsed)).toHaveLength(2);
+        expect(parsed['term.two']).toEqual('deux ⛄ 😀👍 🍉你好');
+        expect(parsed['term.one']).toEqual('un');
+      });
+
+    await request(app.getHttpServer())
+      .get(`/api/v1/projects/${testProject.id}/exports?locale=fr&format=properties`)
+      .set('Authorization', `Bearer ${testingUser.accessToken}`)
+      .expect(200)
+      .expect(async res => {
+        const payload = Buffer.from(res.body).toString();
+        expect(payload).toContain('deux \\u26c4 \\ud83d\\ude00\\ud83d\\udc4d \\ud83c\\udf49\\u4f60\\u597d');
+        const parsed = await propertiesParser(payload);
+        expect(Object.keys(parsed.translations)).toHaveLength(2);
+        expect(parsed.translations.find(t => t.term === 'term.two').translation).toEqual('deux ⛄ 😀👍 🍉你好');
+        expect(parsed.translations.find(t => t.term === 'term.one').translation).toEqual('un');
       });
   });
 

--- a/api/test/import.e2e-spec.ts
+++ b/api/test/import.e2e-spec.ts
@@ -34,7 +34,7 @@ describe('ImportController (e2e)', async () => {
         },
         {
           term: 'term.three',
-          translation: 'drei',
+          translation: 'drei ⛄ 😀👍 🍉你好',
         },
       ],
     })) as string;
@@ -255,7 +255,7 @@ describe('ImportController (e2e)', async () => {
           value: 'zwei',
         });
         const termValues = res.body.data.map(t => t.value);
-        expect(termValues).toContainEqual('drei');
+        expect(termValues).toContainEqual('drei ⛄ 😀👍 🍉你好');
       });
 
     await request(app.getHttpServer())

--- a/api/test/project.e2e-spec.ts
+++ b/api/test/project.e2e-spec.ts
@@ -25,10 +25,36 @@ describe('ProjectController (e2e)', async () => {
       .expect(201)
       .expect(res => {
         expect(res.body.data).toHaveExactProperties(['id', 'name', 'role', 'description', 'termsCount', 'localesCount', 'date']);
+        expect(res.body.data.name).toEqual('My first project');
+        expect(res.body.data.description).toBeNull();
         expect(res.body.data.role).toEqual('admin');
         expect(res.body.data.termsCount).toEqual(0);
         expect(res.body.data.localesCount).toEqual(0);
         projectId = res.body.data.id;
+      });
+  });
+
+  it('/api/v1/projects (POST) should accept projects with utf-8 characters in the name or description', async () => {
+    await request(app.getHttpServer())
+      .post('/api/v1/projects')
+      .set('Authorization', `Bearer ${testingUser.accessToken}`)
+      .send({
+        name: 'My second project őúüöá 😀👍🍉你好',
+        description: '⛄ 😀👍 descriptiön 🍉你好',
+      })
+      .expect(201)
+      .expect(async res => {
+        expect(res.body.data).toHaveExactProperties(['id', 'name', 'role', 'description', 'termsCount', 'localesCount', 'date']);
+        expect(res.body.data.role).toEqual('admin');
+        expect(res.body.data.termsCount).toEqual(0);
+        expect(res.body.data.localesCount).toEqual(0);
+        expect(res.body.data.name).toEqual('My second project őúüöá 😀👍🍉你好');
+        expect(res.body.data.description).toEqual('⛄ 😀👍 descriptiön 🍉你好');
+
+        await request(app.getHttpServer())
+          .delete(`/api/v1/projects/${res.body.data.id}`)
+          .set('Authorization', `Bearer ${testingUser.accessToken}`)
+          .expect(204);
       });
   });
 

--- a/api/test/term.e2e-spec.ts
+++ b/api/test/term.e2e-spec.ts
@@ -59,6 +59,21 @@ describe('TermController (e2e)', () => {
       });
   });
 
+  it('/api/v1/projects/:projectId/terms/:termId (PATCH) should accept terms with utf-8 encoding', async () => {
+    await request(app.getHttpServer())
+      .patch(`/api/v1/projects/${testProject.id}/terms/${termId}`)
+      .set('Authorization', `Bearer ${testingUser.accessToken}`)
+      .send({
+        value: 'term.two őúüöá 😀👍🍉你好',
+      })
+      .expect(200)
+      .expect(res => {
+        expect(res.body.data).toHaveExactProperties(['id', 'value', 'date']);
+        expect(res.body.data.id).toEqual(termId);
+        expect(res.body.data.value).toEqual('term.two őúüöá 😀👍🍉你好');
+      });
+  });
+
   it('/api/v1/projects/:projectId/terms/:termId (DELETE) should delete term by id', async () => {
     await request(app.getHttpServer())
       .delete(`/api/v1/projects/${testProject.id}/terms/${termId}`)

--- a/api/test/translation.e2e-spec.ts
+++ b/api/test/translation.e2e-spec.ts
@@ -160,6 +160,42 @@ describe('TranslationController (e2e)', () => {
       });
   });
 
+  it('/api/v1/projects/:projectId/translations/:localeCode (PATCH) should accept translations with utf-8 characters', async () => {
+    await request(app.getHttpServer())
+      .post(`/api/v1/projects/${testProject.id}/translations`)
+      .set('Authorization', `Bearer ${testingUser.accessToken}`)
+      .send({
+        code: 'de_DE',
+      })
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .patch(`/api/v1/projects/${testProject.id}/translations/de_DE`)
+      .set('Authorization', `Bearer ${testingUser.accessToken}`)
+      .send({
+        termId,
+        value: 'őúüöá',
+      })
+      .expect(200)
+      .expect(res => {
+        expect(res.body.data).toHaveExactProperties(['termId', 'value', 'date']);
+        expect(res.body.data.value).toEqual('őúüöá');
+      });
+
+    await request(app.getHttpServer())
+      .patch(`/api/v1/projects/${testProject.id}/translations/de_DE`)
+      .set('Authorization', `Bearer ${testingUser.accessToken}`)
+      .send({
+        termId,
+        value: 'őúüöá 😀👍🍉你好',
+      })
+      .expect(200)
+      .expect(res => {
+        expect(res.body.data).toHaveExactProperties(['termId', 'value', 'date']);
+        expect(res.body.data.value).toEqual('őúüöá 😀👍🍉你好');
+      });
+  });
+
   it('/api/v1/projects/:projectId/translations/:localeCode (PATCH) should fail to update translation if term or locale not exists', async () => {
     await request(app.getHttpServer())
       .post(`/api/v1/projects/${testProject.id}/translations`)

--- a/api/test/user.e2e-spec.ts
+++ b/api/test/user.e2e-spec.ts
@@ -64,14 +64,14 @@ describe('UserController (e2e)', () => {
       .patch('/api/v1/users/me')
       .set('Authorization', `Bearer ${testingUser.accessToken}`)
       .send({
-        name: 'Updated Name',
+        name: 'Updated Name ⛄ 😀👍 🍉你好',
       })
       .expect(200)
       .expect(res => {
         const payload = res.body.data;
         expect(payload.id).toBeDefined();
         expect(payload.email).toBeDefined();
-        expect(payload.name).toEqual('Updated Name');
+        expect(payload.name).toEqual('Updated Name ⛄ 😀👍 🍉你好');
       });
 
     await request(app.getHttpServer())
@@ -95,7 +95,7 @@ describe('UserController (e2e)', () => {
       .expect(res => {
         const payload = res.body.data;
         expect(payload.id).toBeDefined();
-        expect(payload.name).toEqual('Updated Name');
+        expect(payload.name).toEqual('Updated Name ⛄ 😀👍 🍉你好');
         expect(payload.email).toEqual('updated.email@example.de');
       });
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,7 +8,7 @@ To download the source code for each release, check out [GitHub](https://github.
 
 ## next
 - Suppport Apple .strings format
-- Set default MySQL charset to utf8mb. You can now use emojis in terms and translations 👍.
+- Set default MySQL charset to utf8mb4. You can now use emojis in terms and translations 👍.
 
 ## 0.9.0
 - Added support to import and export Gettext (po) files

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@ To download the source code for each release, check out [GitHub](https://github.
 
 ## next
 - Suppport Apple .strings format
+- Set default MySQL charset to utf8mb. You can now use emojis in terms and translations 👍.
 
 ## 0.9.0
 - Added support to import and export Gettext (po) files


### PR DESCRIPTION
Set default MySQL charset to utf8mb4. You can now use emojis in terms and translations.
