### PR TITLE
Add version to health check

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -67,6 +67,7 @@
     "nodemon": "^1.18.3",
     "prettier": "^1.14.2",
     "rimraf": "^2.6.2",
+    "semver-regex": "^3.1.0",
     "supertest": "^3.1.0",
     "ts-jest": "^24.0.2",
     "ts-loader": "^4.4.2",

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "traduora-api",
-  "version": "0.0.0",
+  "version": "0.12.0",
   "license": "AGPL-3.0-only",
   "scripts": {
     "fmt": "prettier --write \"src/**/*.ts\"",

--- a/api/src/controllers/health.controller.ts
+++ b/api/src/controllers/health.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiUseTags, ApiExcludeEndpoint } from '@nestjs/swagger';
+import { version } from '../../package.json';
 
 @Controller()
 export default class HealthController {
@@ -8,6 +9,6 @@ export default class HealthController {
   @ApiExcludeEndpoint()
   @Get('/health')
   async health() {
-    return { status: 'ok' };
+    return { status: 'ok', version };
   }
 }

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -5,6 +5,8 @@ import { config } from './config';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { ExpressAdapter, NestExpressApplication } from '@nestjs/platform-express';
 
+import { version } from '../package.json';
+
 interface Closable {
   close(): Promise<void>;
 }
@@ -42,7 +44,7 @@ async function bootstrap() {
           'Additional documentation: https://docs.traduora.com\n' +
           'Source code: https://github.com/traduora/traduora',
       )
-      .setVersion('1.0')
+      .setVersion(version)
       .setBasePath('/')
       .addOAuth2('password', '/api/v1/auth/token', '/api/v1/auth/token')
       .setSchemes('http', 'https')

--- a/api/test/health.e2e-spec.ts
+++ b/api/test/health.e2e-spec.ts
@@ -14,7 +14,9 @@ describe('HealthController (e2e)', () => {
       .get('/health')
       .expect(200)
       .expect(res => {
+        expect(res.body).toHaveExactProperties(['status', 'version']);
         expect(res.body.status).toEqual('ok');
+        expect(res.body.version).toMatch(require('semver-regex')());
       });
   });
 

--- a/api/test/health.e2e-spec.ts
+++ b/api/test/health.e2e-spec.ts
@@ -13,8 +13,8 @@ describe('HealthController (e2e)', () => {
     await request(app.getHttpServer())
       .get('/health')
       .expect(200)
-      .expect({
-        status: 'ok',
+      .expect(res => {
+        expect(res.body.status).toEqual('ok');
       });
   });
 

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -6,6 +6,7 @@
     "removeComments": true,
     "noLib": false,
     "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "target": "es6",

--- a/api/tslint.json
+++ b/api/tslint.json
@@ -29,6 +29,10 @@
   },
   "rulesDirectory": [],
   "linterOptions": {
-    "exclude": ["bin", "src/migrations/*"]
+    "exclude": [
+      "bin",
+      "src/migrations/*",
+      "**/*.json"
+    ]
   }
 }

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -5491,6 +5491,11 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
+semver-regex@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-3.1.0.tgz#23368cb577bf2668e78bf9c3e8e519fc029ca069"
+  integrity sha512-xJqZonbAohJmpogzq1Mx7DB4DT3LO+sG5J4i/rcRyZ527dcUqsTVb5T0vM5gwOBf3KO0v7i94EpbdvwSukJyAQ==
+
 "semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"

--- a/bin/version.sh
+++ b/bin/version.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# usage: bin/version.sh 1.2.3
+
+# Hint:
+#   Before releasing you may directly invoke this script.
+#   If versions are defined according to the passed release,
+#   this script is just serving as a verification step.
+
+set -e
+
+if [[ $1 == "" ]]; then
+    echo "No release version set"
+    exit 1
+fi
+
+RELEASE=$1
+
+# sets the version in package.json
+#   `npm version` takes care of ensuring a valid semver version,
+#   or a semver'ish version starting with a zero
+function version {
+    cd $1 > /dev/null
+    echo "Setting version in $(pwd)/$1/package.json"
+    npm version $RELEASE --allow-same-version --git-tag-version false
+    cd - > /dev/null
+}
+
+version .
+version api
+version webapp

--- a/bin/version.sh
+++ b/bin/version.sh
@@ -21,7 +21,7 @@ RELEASE=$1
 #   or a semver'ish version starting with a zero
 function version {
     cd $1 > /dev/null
-    echo "Setting version in $(pwd)/$1/package.json"
+    echo "Setting version in $1/package.json"
     npm version $RELEASE --allow-same-version --git-tag-version false
     cd - > /dev/null
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,9 @@ To download the source code for each release, check out [GitHub](https://github.
 
 ## next
 
+## 0.12.1
+- Release script utilizes [jq](https://stedolan.github.io/jq/) for introspection on release version
+
 ## 0.12.0
 - You can now sign-in with Google.
 - Fix search component case sensitivity.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,7 +11,6 @@ To download the source code for each release, check out [GitHub](https://github.
 ## 0.12.1
 - Ensure swagger version is same as in package.json
 - expose version in `/health` endpoint
-- Release script utilizes [jq](https://stedolan.github.io/jq/) for introspection on release version
 
 ## 0.12.0
 - You can now sign-in with Google.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,8 @@ To download the source code for each release, check out [GitHub](https://github.
 ## next
 
 ## 0.12.1
+- Ensure swagger version is same as in package.json
+- expose version in `/health` endpoint
 - Release script utilizes [jq](https://stedolan.github.io/jq/) for introspection on release version
 
 ## 0.12.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "traduora",
-  "version": "0.0.0",
+  "version": "0.12.0",
   "license": "AGPL-3.0-only",
   "description": "Traduora - translation management platform for teams",
   "repository": "https://github.com/traduora/traduora",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "traduora-webapp",
   "license": "AGPL-3.0-only",
-  "version": "0.0.0",
+  "version": "0.12.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",


### PR DESCRIPTION
In order to make the api client more resilient I would like to read the release tag from someplace.

Thought the `/health` endpoint reasonable.

with this pr it responds with

```json
{
  "status": "ok",
  "version": "0.12.1"
}
```

Caution, I added [jq](https://stedolan.github.io/jq/) to the dependencies of the release script.

In case it is unfamiliar, please give it a chance.

From their readme:

> jq is like sed for JSON data - you can use it to slice and filter and map and transform structured data with the same ease that sed, awk, grep and friends let you play with text.

![Screenshot of swagger header](https://user-images.githubusercontent.com/922226/63458187-9a80b780-c452-11e9-9961-6f0e643219e1.png)
