### PR TITLE
Fix export to JSON/YAML nested, when a key have both a string value and subkeys

### DIFF
--- a/api/src/formatters/jsonnested.ts
+++ b/api/src/formatters/jsonnested.ts
@@ -50,10 +50,17 @@ export const jsonNestedExporter: Exporter = async (data: IntermediateTranslation
         if (!current.hasOwnProperty(key)) {
           current[key] = {};
         }
+        if (typeof current[key] === 'string') {
+          throw new Error(
+            `You have a flat key that have both a value and sub keys. This is not allowed on nested JSON. Sub key: ${translation.term}`,
+          );
+        }
         current = current[key];
       }
+
       current[parts[partsLen - 1]] = translation.translation;
     }
   }
+
   return JSON.stringify(result, null, 4);
 };

--- a/api/src/formatters/yaml-nested.ts
+++ b/api/src/formatters/yaml-nested.ts
@@ -49,6 +49,11 @@ export const yamlNestedExporter: Exporter = async (data: IntermediateTranslation
         if (!current.hasOwnProperty(key)) {
           current[key] = {};
         }
+        if (typeof current[key] === 'string') {
+          throw new Error(
+            `You have a flat key that have both a value and sub keys. This is not allowed on nested JSON. Sub key: ${translation.term}`,
+          );
+        }
         current = current[key];
       }
       current[parts[partsLen - 1]] = translation.translation;

--- a/api/src/formatters/yaml-nested.ts
+++ b/api/src/formatters/yaml-nested.ts
@@ -51,7 +51,7 @@ export const yamlNestedExporter: Exporter = async (data: IntermediateTranslation
         }
         if (typeof current[key] === 'string') {
           throw new Error(
-            `You have a flat key that have both a value and sub keys. This is not allowed on nested JSON. Sub key: ${translation.term}`,
+            `You have a flat key that have both a value and sub keys. This is not allowed on nested YAML. Sub key: ${translation.term}`,
           );
         }
         current = current[key];


### PR DESCRIPTION
# Abstract

This PR add a check that allows JSON & YAML nested exports to more explicitly explain their crash.

Sample flat YAML import. Please notice how `shipping.distribution-points.choose` have both a value, and subkeys.:

```yaml
shipping.distribution-points.choose: Choisir ce point de distribution
shipping.distribution-points.choose.relay: Choisir ce point relais
shipping.distribution-points.choose.shop: Choisir ce magasin
``` 

This is valid in flat YAML, but will prove invalid in any nested JSON or YAML.

# Currently

Currently Traduora will fail, with an error message that might be a little cryptic:

```
TypeError: Cannot create property 'relay' on string 'Choisir ce magasin'
    at Object.<anonymous> (/home/clement/work/traduora/api/src/formatters/jsonnested.ts:61:35)
    at Generator.next (<anonymous>)
    at /home/clement/work/traduora/api/src/formatters/jsonnested.ts:7:71
    at new Promise (<anonymous>)
    at __awaiter (/home/clement/work/traduora/api/src/formatters/jsonnested.ts:3:12)
    at Object.exports.jsonNestedExporter (/home/clement/work/traduora/api/src/formatters/jsonnested.ts:40:91)
    at ExportsController.<anonymous> (/home/clement/work/traduora/api/src/controllers/exports.controller.ts:100:22)
    at Generator.next (<anonymous>)
    at /home/clement/work/traduora/api/src/controllers/exports.controller.ts:19:71
    at new Promise (<anonymous>)
```

# With this PR

This PR brings a proper `Error` with a message that allows easier debugging:

```
Error: You have a flat key that have both a value and sub keys. This is not allowed on nested JSON. Sub key: shipping.distribution-points.distribution-point.choose.relay
    at Object.<anonymous> (/home/clement/work/traduora/api/src/formatters/jsonnested.ts:54:17)
    at Generator.next (<anonymous>)
    at /home/clement/work/traduora/api/src/formatters/jsonnested.ts:7:71
    at new Promise (<anonymous>)
    at __awaiter (/home/clement/work/traduora/api/src/formatters/jsonnested.ts:3:12)
    at Object.exports.jsonNestedExporter (/home/clement/work/traduora/api/src/formatters/jsonnested.ts:40:91)
    at ExportsController.<anonymous> (/home/clement/work/traduora/api/src/controllers/exports.controller.ts:100:22)
    at Generator.next (<anonymous>)
    at /home/clement/work/traduora/api/src/controllers/exports.controller.ts:19:71
    at new Promise (<anonymous>)
```

# Improvements

I am definitely not a node developper, I didn't try to add a proper unit test to ensure no regression on that behavior, though this could be good.