### PR TITLE
Add the term value

### DIFF
--- a/api/src/controllers/translation.controller.ts
+++ b/api/src/controllers/translation.controller.ts
@@ -139,7 +139,7 @@ export default class TranslationController {
       relations: ['term', 'labels'],
     });
 
-    const result = translations.map(t => ({ termId: t.term.id, value: t.value, labels: t.labels, date: t.date }));
+    const result = translations.map(t => ({ termId: t.term.id, term: t.term.value, value: t.value, labels: t.labels, date: t.date }));
 
     return { data: result };
   }


### PR DESCRIPTION
Add the actual term value to allow API calls to retrieve the full list of available translations and use the response directly in the application code.