### PR TITLE
Dockerfile: node base image update 20.11.1 --> 20.19.0  (fix for #459)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG NODE_OPTIONS
 ARG NODE_ENV
 
 # Build stage
-FROM node:20.11.1-alpine3.19 as builder
+FROM node:20.19.0-alpine3.21 as builder
 
 LABEL maintainer="ever@ever.co"
 LABEL org.opencontainers.image.source https://github.com/ever-co/ever-traduora
@@ -43,7 +43,7 @@ RUN dos2unix bin/* && chmod +x bin/*.sh
 RUN bin/build.sh
 
 # Runtime stage
-FROM node:20.11.1-alpine3.19
+FROM node:20.19.0-alpine3.21
 
 ENV NODE_OPTIONS=${NODE_OPTIONS:-"--max-old-space-size=12288"}
 ENV NODE_ENV=${NODE_ENV:-production}


### PR DESCRIPTION
Fixing  #459 ("docker build doesn't work (node version mismatch)")