### PR TITLE
[fix] Skip database server wait when using SQLite

### DIFF
--- a/docker-entrypoint.compose.sh
+++ b/docker-entrypoint.compose.sh
@@ -3,11 +3,11 @@ set -ex
 
 # This Entrypoint used inside Docker Compose only
 
-# Pour SQLite, pas besoin d'attendre un serveur de base de données
+# For SQLite, no need to wait for database server
 if [ "$TR_DB_TYPE" = "better-sqlite3" ]; then
     echo "Using SQLite database, skipping database server wait..."
 else
-    # Pour d'autres types de DB, attendre la connexion
+    # For other database types, wait for connection
     export WAIT_HOSTS=$TR_DB_HOST:$TR_DB_PORT
     ./wait
 fi

--- a/docker-entrypoint.compose.sh
+++ b/docker-entrypoint.compose.sh
@@ -4,7 +4,7 @@ set -ex
 # This Entrypoint used inside Docker Compose only
 
 # For SQLite, no need to wait for database server
-if [ "$TR_DB_TYPE" = "better-sqlite3" ]; then
+if [ "$TR_DB_TYPE" = "better-sqlite3" ] || [ "$TR_DB_TYPE" = "sqlite3" ]; then
     echo "Using SQLite database, skipping database server wait..."
 else
     # For other database types, wait for connection

--- a/docker-entrypoint.compose.sh
+++ b/docker-entrypoint.compose.sh
@@ -3,9 +3,13 @@ set -ex
 
 # This Entrypoint used inside Docker Compose only
 
-export WAIT_HOSTS=$TR_DB_HOST:$TR_DB_PORT
-
-# in Docker Compose we should wait other services start
-./wait
+# Pour SQLite, pas besoin d'attendre un serveur de base de données
+if [ "$TR_DB_TYPE" = "better-sqlite3" ]; then
+    echo "Using SQLite database, skipping database server wait..."
+else
+    # Pour d'autres types de DB, attendre la connexion
+    export WAIT_HOSTS=$TR_DB_HOST:$TR_DB_PORT
+    ./wait
+fi
 
 exec node src/main.js


### PR DESCRIPTION
- Add conditional check for TR_DB_TYPE in docker-entrypoint.compose.sh
- Skip ./wait execution when using better-sqlite3 or sqlite3
- Prevent indefinite waiting for non-existent database server
- Maintain backward compatibility for PostgreSQL/MySQL setups

Fixes container startup hanging with SQLite configuration.

### Before submitting the PR, please make sure you do the following

1.  Contributor license agreement
    For us it's important to have the agreement of our contributors to use their work, whether it be code or documentation. Therefore, we are asking all contributors to sign a contributor license agreement (CLA) as commonly accepted in most open source projects. **Just open the pull request and our CLA bot will prompt you briefly.**

2.  Please check our [contribution guidelines](https://docs.traduora.co/docs/contributing#review-process-for-this-repo) for some help in the process.
