### PR TITLE
fix: Filter translations with missing related Term

### DIFF
--- a/api/src/controllers/translation.controller.ts
+++ b/api/src/controllers/translation.controller.ts
@@ -143,7 +143,7 @@ export default class TranslationController {
           },
           relations: ['term', 'labels'],
         });
-        const result = translations.map(t => ({ termId: t.term.id, value: t.value, labels: t.labels, date: t.date }));
+        const result = translations.filter(t => !!t.term).map(t => ({ termId: t.term.id, value: t.value, labels: t.labels, date: t.date }));
         return { data: result };
       } catch (error) {
         throw new NotFoundException('project translation not found');


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

1.  Contributor license agreement
    For us it's important to have the agreement of our contributors to use their work, whether it be code or documentation. Therefore, we are asking all contributors to sign a contributor license agreement (CLA) as commonly accepted in most open source projects. **Just open the pull request and our CLA bot will prompt you briefly.**

2.  Please check our [contribution guidelines](https://docs.traduora.co/docs/contributing#review-process-for-this-repo) for some help in the process.

### PR Content:
Tentative workaround for when a Translation is missing its Term, to prevent a 404 exception being raised when existing terms are accessible. Addressing: #492 

Not sure if when removing a Term its related Translations should be removed as well but this should allow the endpoint to return valid data independently. I am not too familiar with how Traduora is set up yet, so feel free to let me know if tests are required, or if this might affect performance.