### PR TITLE
Security: Client-side auth guard always returns true after failed auth check

### DIFF
--- a/webapp/src/app/auth/guards/auth.guard.ts
+++ b/webapp/src/app/auth/guards/auth.guard.ts
@@ -16,6 +16,7 @@ export class AuthGuard {
       map(ok => {
         if (!ok) {
           this.store.dispatch(new MustLogin(state.url));
+          return false;
         }
         return true;
       }),


### PR DESCRIPTION
## Problem

The route guard dispatches `MustLogin` when unauthenticated but still returns `true`, allowing navigation to proceed. This can expose protected UI states and data-loading paths to unauthenticated users if backend checks are inconsistent or missing on some endpoints.

**Severity**: `high`
**File**: `webapp/src/app/auth/guards/auth.guard.ts`

## Solution

Return `false` when `ok` is false (or redirect and return `false`), e.g. `if (!ok) { dispatch...; return false; } return true;`.

## Changes

- `webapp/src/app/auth/guards/auth.guard.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops unauthorized navigation by making the client-side auth guard return false when the auth check fails, preventing access to protected routes. Previously, it dispatched `MustLogin` but still returned true, exposing protected UI states.

<sup>Written for commit 36e66fce8e712a4be17d0ae0e903fe0d53e574db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

