### PR TITLE
ci(verdaccio): route dev+stage build through internal Verdaccio VIP (not prod)

### DIFF
--- a/.github/workflows/k8s-build.yml
+++ b/.github/workflows/k8s-build.yml
@@ -43,6 +43,8 @@ jobs:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           push: true
+          build-args: |
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ steps.t.outputs.tag }}
             ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:sha-${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,19 @@ COPY webapp webapp
 
 RUN dos2unix bin/* && chmod +x bin/*.sh
 
+# Configure the npm/yarn registry: prefer the internal Verdaccio cache (VERDACCIO_REGISTRY build-arg,
+# anonymous), else public npm (empty, e.g. a fork). Writing to the home-level .npmrc/.yarnrc makes it
+# apply to all installs run by bin/install-deps.sh (root, webapp and api). The yarn.lock rewrites are
+# best-effort (non-fatal) so a path mismatch degrades to public downloads rather than breaking the build.
+ARG VERDACCIO_REGISTRY=""
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+		echo "registry=${VERDACCIO_REGISTRY}" >> "$HOME/.npmrc" && \
+		printf 'registry "%s"\n' "${VERDACCIO_REGISTRY}" >> "$HOME/.yarnrc" && \
+		for lock in yarn.lock webapp/yarn.lock api/yarn.lock; do \
+			sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g; s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" "$lock" 2>/dev/null || true; \
+		done; \
+	fi
+
 RUN bin/build.sh
 
 # Runtime stage

--- a/Dockerfile.everk8s
+++ b/Dockerfile.everk8s
@@ -19,6 +19,16 @@ COPY docs-website ./docs-website
 
 WORKDIR /app/docs-website
 
+# Configure the npm/yarn registry: prefer the internal Verdaccio cache (VERDACCIO_REGISTRY build-arg,
+# anonymous), else public npm (empty, e.g. a fork). The yarn.lock rewrite is best-effort (non-fatal) so a
+# path mismatch degrades to public downloads rather than breaking the build.
+ARG VERDACCIO_REGISTRY=""
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+        echo "registry=${VERDACCIO_REGISTRY}" >> "$HOME/.npmrc" && \
+        printf 'registry "%s"\n' "${VERDACCIO_REGISTRY}" >> "$HOME/.yarnrc" && \
+        { sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g; s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock 2>/dev/null || true; }; \
+    fi
+
 # Install deps (fall back to a non-frozen install if the lockfile drifts)
 RUN yarn install --frozen-lockfile --non-interactive \
     || yarn install --non-interactive


### PR DESCRIPTION
## What

Route the in-cluster Docker builds of **ever-traduora** through our internal **Verdaccio** cache VIP for npm/yarn dependency installs, instead of hitting public npm on every build.

The single build workflow (`.github/workflows/k8s-build.yml`) is **not env-split** — it builds `dev`/`stage`/`prod` tags from one job on our ARC runners (`vars.RUNNER_LINUX_X64_8 || vars.RUNNER_LINUX_X64_4`). Only ARC runners can reach the internal VIP, so this is the correct place to wire it. No prod-specific workflow was touched.

## Changes

- **`.github/workflows/k8s-build.yml`** — add a `build-args` block passing `VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}` to `docker/build-push-action`. Applies to both matrix images (`ever-traduora` app + `ever-traduora-docs`).
- **`Dockerfile`** (app image) — before `RUN bin/build.sh` (which runs `bin/install-deps.sh` → `yarn` at root, `webapp`, `api`), add a backward-compatible `ARG VERDACCIO_REGISTRY` block. When set, it writes `registry=` to the home-level `~/.npmrc` + `~/.yarnrc` (covers all three workspace installs) and does a **non-fatal** `sed` of the `resolved` URLs in `yarn.lock`, `webapp/yarn.lock`, `api/yarn.lock`.
- **`Dockerfile.everk8s`** (docs image) — before the `yarn install` in `/app/docs-website`, add the same `ARG VERDACCIO_REGISTRY` block (home-level `.npmrc`/`.yarnrc` + non-fatal `sed` of `docs-website/yarn.lock`).

## Backward-compatible + fork-safe

- The VIP IP is **never hardcoded** — it comes only from the `VERDACCIO_REGISTRY` repo variable.
- **Empty `VERDACCIO_REGISTRY`** (a fork, or any build where the var is unset) → the if-block is skipped entirely and installs fall back to **public npm** exactly as today.
- The `yarn.lock` rewrites are all `|| true` (non-fatal): a path/URL mismatch degrades to public downloads rather than breaking the build.
- No existing `VERDACCIO_TOKEN`/`packages.ever.co` logic exists in this repo, so only the `VERDACCIO_REGISTRY` if-block was added (no legacy `elif`).

**Do not merge** without owner review.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route dev and stage Docker builds through the internal `Verdaccio` VIP for npm/yarn installs to speed builds and reduce public registry traffic. If `VERDACCIO_REGISTRY` is unset, builds fall back to public npm (keeps prod/forks unchanged).

- **Refactors**
  - Pass `VERDACCIO_REGISTRY` to `docker/build-push-action` in `.github/workflows/k8s-build.yml`.
  - Add `ARG VERDACCIO_REGISTRY` to `Dockerfile` and `Dockerfile.everk8s` to write `~/.npmrc`/`~/.yarnrc` and best-effort `yarn.lock` rewrites (non-fatal).
  - Gated by `vars.VERDACCIO_REGISTRY`; active on ARC runners that can reach the VIP.

<sup>Written for commit 868ea95bf630cd0702c9a80ff51f6acfa296b2a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-traduora/pull/536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

