### PR TITLE
fix(security): 2 improvements across 1 files

### DIFF
--- a/api/src/formatters/csv.ts
+++ b/api/src/formatters/csv.ts
@@ -42,14 +42,11 @@ export const csvParser: Parser = async (data: string) => {
  * @returns
  */
 const csvInjectionProtector = (str: string) => {
-  const riskyChars = ['=', '+', '-', '@', ',', ';', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0x0d', '/C', '.exe', '\\', '/', '.dll', '|'];
+  const riskyChars = ['=', '+', '-', '@', ',', ';'];
   if (!str) return '';
 
-  /**
-   * Check first character of string
-   */
   if (riskyChars.includes(str.charAt(0))) {
-    return str.replace(str.charAt(0), '');
+    return `'${str}`;
   }
   return str;
 };


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 1 files

## Problem

**Severity**: `Medium` | **File**: `api/src/formatters/csv.ts:L37`

The `csvInjectionProtector` function attempts to prevent CSV injection by stripping characters like `=`, `+`, `-`, `@`, and even digits `0-9` if they appear as the first character of a term or translation. This is overly aggressive and will corrupt legitimate translations that start with these characters (e.g., a translation starting with a number or a minus sign). Additionally, it fails to mitigate multi-line payloads that could be used for CSV injection.

## Solution

Instead of stripping risky characters, prefix them with a single quote (`'`) or a tab character. This neutralizes formula execution in spreadsheet applications without altering the actual string content. For example: `if (riskyChars.includes(str.charAt(0))) { return "'" + str; }`

## Changes

- `api/src/formatters/csv.ts` (modified)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CSV injection handling by preserving legitimate values and preventing formula execution. We now prefix risky leading characters with a single quote instead of stripping them.

- **Bug Fixes**
  - Prefix a single quote when a value starts with one of: `=`, `+`, `-`, `@`, `,`, `;` to neutralize formulas without altering content.
  - Remove overly broad risky set (digits and file-like patterns) to avoid corrupting values that begin with numbers or symbols.

<sup>Written for commit 8e64d46535f2193eff49485edbc58ac911f5c4be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-traduora/pull/537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

