### PR TITLE
ci: add k8s-build pipeline to prod (master) — fresh :prod build

### DIFF
--- a/.github/workflows/k8s-build.yml
+++ b/.github/workflows/k8s-build.yml
@@ -1,0 +1,52 @@
+name: k8s-build
+on:
+  workflow_dispatch:
+  push:
+    branches: [develop, stage, main, master]
+concurrency:
+  group: k8s-build-${{ github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+  packages: write
+jobs:
+  build:
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: ever-traduora
+            dockerfile: Dockerfile
+            context: .
+          - image: ever-traduora-docs
+            dockerfile: Dockerfile.everk8s
+            context: .
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: t
+        run: |
+          case "${GITHUB_REF_NAME}" in
+            develop) echo "tag=dev" >> "$GITHUB_OUTPUT" ;;
+            stage) echo "tag=stage" >> "$GITHUB_OUTPUT" ;;
+            main|master) echo "tag=prod" >> "$GITHUB_OUTPUT" ;;
+            *) echo "tag=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT" ;;
+          esac
+      - uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          build-args: |
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ steps.t.outputs.tag }}
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:sha-${{ github.sha }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:buildcache,mode=max

--- a/Dockerfile.everk8s
+++ b/Dockerfile.everk8s
@@ -1,0 +1,52 @@
+# syntax=docker/dockerfile:1
+# ever-traduora-docs — Docusaurus v1 static docs site
+# Build context = repo root (the site in docs-website/ resolves its content from ../docs).
+# Output of docusaurus-build (projectName "traduora") -> docs-website/build/traduora
+# Served as static files by nginx.
+
+# ---- Build stage ----
+FROM node:20-alpine AS builder
+
+# git + build toolchain: docusaurus v1 deps (jpegtran-bin, etc.) may compile native binaries
+RUN apk add --no-cache git python3 make g++ bash libc6-compat
+
+WORKDIR /app
+
+# Docusaurus v1 reads docs content from ../docs relative to the website dir.
+# Copy both so the relative resolution works.
+COPY docs ./docs
+COPY docs-website ./docs-website
+
+WORKDIR /app/docs-website
+
+# Configure the npm/yarn registry: prefer the internal Verdaccio cache (VERDACCIO_REGISTRY build-arg,
+# anonymous), else public npm (empty, e.g. a fork). The yarn.lock rewrite is best-effort (non-fatal) so a
+# path mismatch degrades to public downloads rather than breaking the build.
+ARG VERDACCIO_REGISTRY=""
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+        echo "registry=${VERDACCIO_REGISTRY}" >> "$HOME/.npmrc" && \
+        printf 'registry "%s"\n' "${VERDACCIO_REGISTRY}" >> "$HOME/.yarnrc" && \
+        { sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g; s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock 2>/dev/null || true; }; \
+    fi
+
+# Install deps (fall back to a non-frozen install if the lockfile drifts)
+RUN yarn install --frozen-lockfile --non-interactive \
+    || yarn install --non-interactive
+
+# Build the static site -> /app/docs-website/build/traduora
+RUN yarn build
+
+# ---- Runtime stage ----
+FROM nginx:alpine
+
+# Multi-page site: custom conf handles docusaurus v1 cleanUrl (page -> page.html)
+COPY docs-website/nginx.conf /etc/nginx/conf.d/default.conf
+
+# Copy the generated static site (projectName = "traduora")
+COPY --from=builder /app/docs-website/build/traduora /usr/share/nginx/html
+
+EXPOSE 80
+
+STOPSIGNAL SIGQUIT
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/docs-website/nginx.conf
+++ b/docs-website/nginx.conf
@@ -1,0 +1,27 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  _;
+
+    root   /usr/share/nginx/html;
+    index  index.html;
+
+    # Docusaurus v1 cleanUrl: requests for /page resolve to /page/index.html or /page.html.
+    # This is a multi-page site, so do NOT SPA-fallback to a single index.html.
+    location / {
+        try_files $uri $uri/ $uri.html =404;
+    }
+
+    error_page 404 /404.html;
+
+    location = /404.html {
+        internal;
+    }
+
+    # Long-cache immutable hashed assets
+    location ~* \.(?:css|js|woff2?|ttf|eot|svg|png|jpe?g|gif|ico)$ {
+        expires 30d;
+        add_header Cache-Control "public, max-age=2592000";
+        try_files $uri =404;
+    }
+}


### PR DESCRIPTION
Pipeline-only: adds k8s-build.yml + Dockerfile.everk8s + docs-website/nginx.conf (all net-new on master, verbatim from develop). No app content touched. master is now a strict ancestor of develop (Q1 divergence resolved), so develop is source-of-truth; this only adds the CI so master builds ever-traduora:prod + ever-traduora-docs:prod from prod's own content.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `k8s-build` GitHub Actions workflow and docs build assets so `master` can build and push prod images from its own content. Builds and pushes `ever-traduora` and `ever-traduora-docs` images (including `:prod` on `master`); no app code changes.

- **New Features**
  - Added `.github/workflows/k8s-build.yml` to build and push two images with Buildx; tags `dev|stage|prod` plus `sha-*`; pushes to GHCR with registry cache and per-ref concurrency; triggers on `develop`, `stage`, `main`, `master`, and `workflow_dispatch`.
  - Added `Dockerfile.everk8s` to build the Docusaurus v1 docs site with optional `VERDACCIO_REGISTRY`, then serve via NGINX.
  - Added `docs-website/nginx.conf` for clean URL routing (no SPA fallback) and long-cache static assets.

<sup>Written for commit ed3cbf51aa14b697168b86a898d9671aba3a28b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-traduora/pull/538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

