### PR TITLE
build(deps): bump nodemailer from 7.0.11 to 8.0.11 in /api

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -62,7 +62,7 @@
     "mysql2": "^3.14.0",
     "better-sqlite3": "^9.6.0",
     "node-native2ascii": "^0.2.0",
-    "nodemailer": "^7.0.7",
+    "nodemailer": "^8.0.11",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16526,10 +16526,10 @@ nodemailer@^6.9.13:
   resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.10.1.tgz#cbc434c54238f83a51c07eabd04e2b3e832da623"
   integrity sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==
 
-nodemailer@^7.0.7:
-  version "7.0.11"
-  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-7.0.11.tgz#5f7b06afaec20073cff36bea92d1c7395cc3e512"
-  integrity sha512-gnXhNRE0FNhD7wPSCGhdNh46Hs6nm+uTyg+Kq0cZukNQiYdnCsoQjodNP9BQVG9XrcK/v6/MgpAPBUFyzh9pvw==
+nodemailer@^8.0.11:
+  version "8.0.11"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-8.0.11.tgz#ce46b7c2c8bbf17b0408122fbfb4e47f4bffc688"
+  integrity sha512-nrO/pDAUKl+wXX+lx16tDLbnm0fW6sK/x8mgohaCpg+CdCEl482bD4tCuAZk2DyliruiNTIZxRCoWkDqJEnAiA==
 
 nodemon@^3.1.4:
   version "3.1.4"


### PR DESCRIPTION
Bumps `nodemailer` **7.0.11 → 8.0.11** in `/api`.

### Why a fresh PR instead of the dependabot one
Supersedes the orphaned dependabot PR #534 (7.0.11→8.0.5). That PR was **63 commits behind develop** with a **2026-04-08** CI result, and dependabot refused to rebase it ("the dependabot.yml entry that created this PR has been deleted" — it predates the grouped config). This branch is rebased fresh onto current `develop` so the build-gate is meaningful.

### Scope / safety
- Diff is exactly `api/package.json` + root `yarn.lock` (same footprint dependabot used).
- nodemailer 8 is **dependency-free**; `engines: node >=6` (api targets Node >=18 → no conflict).
- Gate on this repo's real `test` (CircleCI) check.

Cascade to `master` intentionally deferred (per owner) — this targets `develop` only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded `nodemailer` in `/api` from 7.0.11 to 8.0.11 to stay current with the latest major release.
Only `api/package.json` and `yarn.lock` changed; rebased with the latest `develop`, and `nodemailer@8` (Node >=6) remains compatible with our Node >=18 runtime.

<sup>Written for commit dbfafc426f626d8116353608efb520cfb0910b5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-traduora/pull/543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

