### PR TITLE
style(docs-website): fix pre-existing prettier failures blocking CI

### DIFF
--- a/docs-website/docusaurus.config.ts
+++ b/docs-website/docusaurus.config.ts
@@ -13,202 +13,200 @@ const GITHUB_REPO_URL = 'https://github.com/ever-co/ever-traduora';
 
 /** @type {import('@docusaurus/types').Config} */
 const config: Config = {
-	themes: [
-		[
-			'@easyops-cn/docusaurus-search-local',
-			/** @type {import("@easyops-cn/docusaurus-search-local").PluginOptions} */
-			{
-				hashed: true,
-				language: ['en'],
-				indexBlog: false,
-				highlightSearchTermsOnTargetPage: true,
-				explicitSearchResultPath: true,
-				docsRouteBasePath: '/',
-				docsDir: '../docs'
-			}
-		],
-		'@docusaurus/theme-mermaid'
-	],
-	plugins: [
-		[
-			'@docusaurus/plugin-client-redirects',
-			{
-				// Preserve legacy Docusaurus-v1 URLs (docs were served under /docs/*).
-				createRedirects(existingPath: string) {
-					if (existingPath === '/') {
-						return ['/docs'];
-					}
-					return [`/docs${existingPath}`];
-				}
-			}
-		],
-		SENTRY_DNS &&
-			process.env.NODE_ENV === 'production' && [
-				'docusaurus-plugin-sentry',
-				{
-					DSN: process.env.NEXT_PUBLIC_SENTRY_DNS
-				}
-			]
-	],
-	title: 'Ever Traduora',
-	tagline: 'Ever® Traduora — Open-source translation management platform',
-	favicon: 'img/favicon.ico',
-	url: 'https://docs.traduora.co',
-	baseUrl: '/',
+  themes: [
+    [
+      '@easyops-cn/docusaurus-search-local',
+      /** @type {import("@easyops-cn/docusaurus-search-local").PluginOptions} */
+      {
+        hashed: true,
+        language: ['en'],
+        indexBlog: false,
+        highlightSearchTermsOnTargetPage: true,
+        explicitSearchResultPath: true,
+        docsRouteBasePath: '/',
+        docsDir: '../docs',
+      },
+    ],
+    '@docusaurus/theme-mermaid',
+  ],
+  plugins: [
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        // Preserve legacy Docusaurus-v1 URLs (docs were served under /docs/*).
+        createRedirects(existingPath: string) {
+          if (existingPath === '/') {
+            return ['/docs'];
+          }
+          return [`/docs${existingPath}`];
+        },
+      },
+    ],
+    SENTRY_DNS &&
+      process.env.NODE_ENV === 'production' && [
+        'docusaurus-plugin-sentry',
+        {
+          DSN: process.env.NEXT_PUBLIC_SENTRY_DNS,
+        },
+      ],
+  ],
+  title: 'Ever Traduora',
+  tagline: 'Ever® Traduora — Open-source translation management platform',
+  favicon: 'img/favicon.ico',
+  url: 'https://docs.traduora.co',
+  baseUrl: '/',
 
-	organizationName: 'ever-co',
-	projectName: 'ever-traduora',
+  organizationName: 'ever-co',
+  projectName: 'ever-traduora',
 
-	onBrokenLinks: 'warn',
-	markdown: {
-		format: 'detect',
-		mermaid: true,
-		hooks: {
-			onBrokenMarkdownLinks: 'warn'
-		}
-	},
-	// Docusaurus built-in field — serves repo-root docs/assets (screenshots) and
-	// the local static/ folder (favicons, static Swagger UI viewer).
-	staticDirectories: ['../docs/assets', 'static'],
-	i18n: {
-		path: 'i18n',
-		defaultLocale: 'en',
-		locales: ['en']
-	},
-	presets: [
-		[
-			'classic',
-			/** @type {import('@docusaurus/preset-classic').Options} */
-			{
-				blog: false,
-				docs: {
-					sidebarPath: './sidebars.ts',
-					path: '../docs/',
-					routeBasePath: '/',
-					editUrl: 'https://github.com/ever-co/ever-traduora/tree/develop/docs/'
-				},
-				theme: {
-					customCss: './src/css/custom.css'
-				},
-				gtag: process.env.GA_TRACKING_ID
-					? { trackingID: process.env.GA_TRACKING_ID, anonymizeIP: true }
-					: undefined
-			}
-		]
-	],
-	themeConfig:
-		/** @type {import('@docusaurus/preset-classic').ThemeConfig} */
-		{
-			image: 'img/traduora-preview.png',
+  onBrokenLinks: 'warn',
+  markdown: {
+    format: 'detect',
+    mermaid: true,
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
+    },
+  },
+  // Docusaurus built-in field — serves repo-root docs/assets (screenshots) and
+  // the local static/ folder (favicons, static Swagger UI viewer).
+  staticDirectories: ['../docs/assets', 'static'],
+  i18n: {
+    path: 'i18n',
+    defaultLocale: 'en',
+    locales: ['en'],
+  },
+  presets: [
+    [
+      'classic',
+      /** @type {import('@docusaurus/preset-classic').Options} */
+      {
+        blog: false,
+        docs: {
+          sidebarPath: './sidebars.ts',
+          path: '../docs/',
+          routeBasePath: '/',
+          editUrl: 'https://github.com/ever-co/ever-traduora/tree/develop/docs/',
+        },
+        theme: {
+          customCss: './src/css/custom.css',
+        },
+        gtag: process.env.GA_TRACKING_ID ? { trackingID: process.env.GA_TRACKING_ID, anonymizeIP: true } : undefined,
+      },
+    ],
+  ],
+  themeConfig:
+    /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
+    {
+      image: 'img/traduora-preview.png',
 
-			colorMode: {
-				defaultMode: 'dark'
-			},
-			navbar: {
-				style: 'dark',
-				logo: {
-					alt: 'traduora Logo',
-					src: 'img/logo.png'
-				},
-				items: [
-					{
-						type: 'docSidebar',
-						sidebarId: 'docs',
-						position: 'left',
-						label: 'Docs'
-					},
-					{ to: '/getting-started', label: 'Getting started', position: 'left' },
-					{ to: '/api/v1/overview', label: 'API', position: 'left' },
-					{
-						href: GITHUB_REPO_URL,
-						label: 'GitHub',
-						position: 'right',
-						className: 'header-github-link'
-					}
-				]
-			},
-			footer: {
-				style: 'dark',
-				logo: {
-					src: 'img/logo.png',
-					height: 40
-				},
-				links: [
-					{
-						title: 'Docs',
-						items: [
-							{ label: 'Getting Started', to: '/getting-started' },
-							{ label: 'Configuration', to: '/configuration' },
-							{ label: 'API reference', to: '/api/v1/overview' },
-							{ label: 'CLI', to: '/tools/cli' }
-						]
-					},
-					{
-						title: 'Community',
-						items: [
-							{ label: 'Docker Hub', href: 'https://hub.docker.com/r/everco/ever-traduora' },
-							{ label: 'GitHub', href: GITHUB_REPO_URL },
-							{ label: 'Contributing', to: '/contributing' }
-						]
-					},
-					{
-						title: 'More',
-						items: [
-							{ label: 'traduora.co', href: 'https://traduora.co' },
-							{ label: 'Changelog', to: '/changelog' },
-							{ label: 'FAQ', to: '/faq' }
-						]
-					}
-				],
-				copyright: `Copyright © 2020-${new Date().getFullYear()} <a href="https://ever.co/" target="_blank" rel="noopener noreferrer" style="color: inherit; text-decoration: underline;">Ever Co. LTD.</a> and contributors.`
-			},
-			algolia: HAS_ALGOLIA_CREDENTIALS
-				? {
-						appId: process.env.ALGOLIA_APP_ID,
-						apiKey: process.env.ALGOLIA_API_KEY,
-						indexName: process.env.ALGOLIA_INDEX_NAME,
-						contextualSearch: true,
-						searchPagePath: 'search',
-						insights: false
-					}
-				: undefined,
-			prism: {
-				theme: prismThemes.github,
-				darkTheme: prismThemes.dracula,
-				additionalLanguages: ['bash', 'json', 'php', 'ini']
-			}
-		},
-	customFields: {
-		footerData: {
-			description:
-				'traduora is an open-source translation management platform — import and export in multiple formats, translate through the UI or the API, and automate your localization workflow.',
-			socialLinks: [
-				{ title: 'GitHub', href: GITHUB_REPO_URL, icon: 'github' },
-				{ title: 'X', href: 'https://x.com/everplatform', icon: 'twitter' },
-				{ title: 'Discord', href: 'https://discord.gg/msqRJ4w', icon: 'discord' }
-			],
-			systemStatus: {
-				status: 'normal',
-				message: 'All systems operational'
-			},
-			products: [
-				{ name: 'Ever Gauzy', href: 'https://gauzy.co', description: 'Open Business Management Platform', icon: '/img/logo.png' },
-				{ name: 'Ever Teams', href: 'https://ever.team', description: 'Open Work & Project Management', icon: '/img/logo.png' },
-				{ name: 'Ever Works', href: 'https://ever.works', description: 'The Workshop for AI', icon: '/img/logo.png' },
-				{ name: 'traduora', href: 'https://traduora.co', description: 'Open Translation Management', icon: '/img/logo.png' }
-			],
-			companyInfo: {
-				copyright: `Copyright © ${new Date().getFullYear()} Ever Co. LTD. All Rights Reserved.`,
-				disclaimer:
-					'*All product names, logos, and brands are property of their respective owners. All company, product and service names used in this website are for identification purposes only. Use of these names, logos, and brands does not imply endorsement.',
-				legalLinks: [
-					{ text: 'Privacy Policy', href: 'https://ever.co/privacy' },
-					{ text: 'Terms of Service', href: 'https://ever.co/tos' },
-					{ text: 'Cookie Policy', href: 'https://ever.co/cookies' }
-				]
-			}
-		}
-	}
+      colorMode: {
+        defaultMode: 'dark',
+      },
+      navbar: {
+        style: 'dark',
+        logo: {
+          alt: 'traduora Logo',
+          src: 'img/logo.png',
+        },
+        items: [
+          {
+            type: 'docSidebar',
+            sidebarId: 'docs',
+            position: 'left',
+            label: 'Docs',
+          },
+          { to: '/getting-started', label: 'Getting started', position: 'left' },
+          { to: '/api/v1/overview', label: 'API', position: 'left' },
+          {
+            href: GITHUB_REPO_URL,
+            label: 'GitHub',
+            position: 'right',
+            className: 'header-github-link',
+          },
+        ],
+      },
+      footer: {
+        style: 'dark',
+        logo: {
+          src: 'img/logo.png',
+          height: 40,
+        },
+        links: [
+          {
+            title: 'Docs',
+            items: [
+              { label: 'Getting Started', to: '/getting-started' },
+              { label: 'Configuration', to: '/configuration' },
+              { label: 'API reference', to: '/api/v1/overview' },
+              { label: 'CLI', to: '/tools/cli' },
+            ],
+          },
+          {
+            title: 'Community',
+            items: [
+              { label: 'Docker Hub', href: 'https://hub.docker.com/r/everco/ever-traduora' },
+              { label: 'GitHub', href: GITHUB_REPO_URL },
+              { label: 'Contributing', to: '/contributing' },
+            ],
+          },
+          {
+            title: 'More',
+            items: [
+              { label: 'traduora.co', href: 'https://traduora.co' },
+              { label: 'Changelog', to: '/changelog' },
+              { label: 'FAQ', to: '/faq' },
+            ],
+          },
+        ],
+        copyright: `Copyright © 2020-${new Date().getFullYear()} <a href="https://ever.co/" target="_blank" rel="noopener noreferrer" style="color: inherit; text-decoration: underline;">Ever Co. LTD.</a> and contributors.`,
+      },
+      algolia: HAS_ALGOLIA_CREDENTIALS
+        ? {
+            appId: process.env.ALGOLIA_APP_ID,
+            apiKey: process.env.ALGOLIA_API_KEY,
+            indexName: process.env.ALGOLIA_INDEX_NAME,
+            contextualSearch: true,
+            searchPagePath: 'search',
+            insights: false,
+          }
+        : undefined,
+      prism: {
+        theme: prismThemes.github,
+        darkTheme: prismThemes.dracula,
+        additionalLanguages: ['bash', 'json', 'php', 'ini'],
+      },
+    },
+  customFields: {
+    footerData: {
+      description:
+        'traduora is an open-source translation management platform — import and export in multiple formats, translate through the UI or the API, and automate your localization workflow.',
+      socialLinks: [
+        { title: 'GitHub', href: GITHUB_REPO_URL, icon: 'github' },
+        { title: 'X', href: 'https://x.com/everplatform', icon: 'twitter' },
+        { title: 'Discord', href: 'https://discord.gg/msqRJ4w', icon: 'discord' },
+      ],
+      systemStatus: {
+        status: 'normal',
+        message: 'All systems operational',
+      },
+      products: [
+        { name: 'Ever Gauzy', href: 'https://gauzy.co', description: 'Open Business Management Platform', icon: '/img/logo.png' },
+        { name: 'Ever Teams', href: 'https://ever.team', description: 'Open Work & Project Management', icon: '/img/logo.png' },
+        { name: 'Ever Works', href: 'https://ever.works', description: 'The Workshop for AI', icon: '/img/logo.png' },
+        { name: 'traduora', href: 'https://traduora.co', description: 'Open Translation Management', icon: '/img/logo.png' },
+      ],
+      companyInfo: {
+        copyright: `Copyright © ${new Date().getFullYear()} Ever Co. LTD. All Rights Reserved.`,
+        disclaimer:
+          '*All product names, logos, and brands are property of their respective owners. All company, product and service names used in this website are for identification purposes only. Use of these names, logos, and brands does not imply endorsement.',
+        legalLinks: [
+          { text: 'Privacy Policy', href: 'https://ever.co/privacy' },
+          { text: 'Terms of Service', href: 'https://ever.co/tos' },
+          { text: 'Cookie Policy', href: 'https://ever.co/cookies' },
+        ],
+      },
+    },
+  },
 };
 
 export default config;

--- a/docs-website/sidebars.ts
+++ b/docs-website/sidebars.ts
@@ -5,41 +5,35 @@ import type { SidebarsConfig } from '@docusaurus/plugin-content-docs';
  * (Quickstart / Concepts / API reference / Tools / Misc).
  */
 const sidebars: SidebarsConfig = {
-	docs: [
-		'index',
-		{
-			type: 'category',
-			label: 'Quickstart',
-			collapsed: false,
-			items: ['getting-started', 'screenshots', 'deployment', 'configuration']
-		},
-		{
-			type: 'category',
-			label: 'Concepts',
-			items: ['concepts/formats']
-		},
-		{
-			type: 'category',
-			label: 'API reference',
-			items: [
-				'api/v1/overview',
-				'api/v1/authentication',
-				'api/v1/roles-permissions',
-				'api/v1/endpoints',
-				'api/v1/errors'
-			]
-		},
-		{
-			type: 'category',
-			label: 'Tools',
-			items: ['tools/cli']
-		},
-		{
-			type: 'category',
-			label: 'Misc',
-			items: ['changelog', 'contributing', 'faq']
-		}
-	]
+  docs: [
+    'index',
+    {
+      type: 'category',
+      label: 'Quickstart',
+      collapsed: false,
+      items: ['getting-started', 'screenshots', 'deployment', 'configuration'],
+    },
+    {
+      type: 'category',
+      label: 'Concepts',
+      items: ['concepts/formats'],
+    },
+    {
+      type: 'category',
+      label: 'API reference',
+      items: ['api/v1/overview', 'api/v1/authentication', 'api/v1/roles-permissions', 'api/v1/endpoints', 'api/v1/errors'],
+    },
+    {
+      type: 'category',
+      label: 'Tools',
+      items: ['tools/cli'],
+    },
+    {
+      type: 'category',
+      label: 'Misc',
+      items: ['changelog', 'contributing', 'faq'],
+    },
+  ],
 };
 
 export default sidebars;

--- a/docs-website/src/theme.d.ts
+++ b/docs-website/src/theme.d.ts
@@ -1,63 +1,63 @@
 declare module '@theme/Layout' {
-	export interface Props {
-		readonly title?: string;
-		readonly description?: string;
-	}
+  export interface Props {
+    readonly title?: string;
+    readonly description?: string;
+  }
 }
 
 declare module '@theme/Heading' {
-	type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
-	// Hoisted to a named alias because prettier's TS parser can't
-	// handle the `interface X extends import('...').Y<Z>` form
-	// (SyntaxError: "Interface declaration can only extend an
-	// identifier/qualified name with optional type arguments").
-	type HeadingComponentProps = import('react').ComponentProps<HeadingTag>;
-	export interface Props extends HeadingComponentProps {
-		readonly as: HeadingTag;
-		readonly children?: import('react').ReactNode;
-		readonly className?: string;
-		readonly id?: string;
-	}
-	export default function Heading(props: Props): JSX.Element;
+  type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  // Hoisted to a named alias because prettier's TS parser can't
+  // handle the `interface X extends import('...').Y<Z>` form
+  // (SyntaxError: "Interface declaration can only extend an
+  // identifier/qualified name with optional type arguments").
+  type HeadingComponentProps = import('react').ComponentProps<HeadingTag>;
+  export interface Props extends HeadingComponentProps {
+    readonly as: HeadingTag;
+    readonly children?: import('react').ReactNode;
+    readonly className?: string;
+    readonly id?: string;
+  }
+  export default function Heading(props: Props): JSX.Element;
 }
 
 declare module '@theme/Tabs' {
-	export interface Props {
-		readonly children?: import('react').ReactNode;
-		readonly groupId?: string;
-		readonly className?: string;
-	}
-	export default function Tabs(props: Props): JSX.Element;
+  export interface Props {
+    readonly children?: import('react').ReactNode;
+    readonly groupId?: string;
+    readonly className?: string;
+  }
+  export default function Tabs(props: Props): JSX.Element;
 }
 
 declare module '@theme/TabItem' {
-	export interface Props {
-		readonly children?: import('react').ReactNode;
-		readonly value: string;
-		readonly label?: import('react').ReactNode;
-		readonly default?: boolean;
-		readonly className?: string;
-	}
-	export default function TabItem(props: Props): JSX.Element;
+  export interface Props {
+    readonly children?: import('react').ReactNode;
+    readonly value: string;
+    readonly label?: import('react').ReactNode;
+    readonly default?: boolean;
+    readonly className?: string;
+  }
+  export default function TabItem(props: Props): JSX.Element;
 }
 
 declare module '@theme/CodeBlock' {
-	export interface Props {
-		readonly children?: import('react').ReactNode;
-		readonly language?: string;
-		readonly title?: string;
-		readonly className?: string;
-	}
-	export default function CodeBlock(props: Props): JSX.Element;
+  export interface Props {
+    readonly children?: import('react').ReactNode;
+    readonly language?: string;
+    readonly title?: string;
+    readonly className?: string;
+  }
+  export default function CodeBlock(props: Props): JSX.Element;
 }
 
 declare module '@theme/Footer/Copyright' {
-	export interface Props {
-		readonly copyright?: string;
-	}
-	export default function FooterCopyright(props: Props): JSX.Element;
+  export interface Props {
+    readonly copyright?: string;
+  }
+  export default function FooterCopyright(props: Props): JSX.Element;
 }
 
 declare module '@theme/SearchBar' {
-	export default function SearchBar(): JSX.Element;
+  export default function SearchBar(): JSX.Element;
 }

--- a/docs-website/src/theme/SearchBar/types.d.ts
+++ b/docs-website/src/theme/SearchBar/types.d.ts
@@ -1,19 +1,19 @@
 declare module '@easyops-cn/docusaurus-search-local/dist/client/client/theme/searchByWorker' {
-	export function fetchIndexesByWorker(baseUrl: string, searchContext: string): Promise<void>;
+  export function fetchIndexesByWorker(baseUrl: string, searchContext: string): Promise<void>;
 
-	export function searchByWorker(
-		baseUrl: string,
-		searchContext: string,
-		query: string
-	): Promise<
-		Array<{
-			document: {
-				u: string;
-				t: string;
-				h?: string;
-				s?: string;
-			};
-			tokens: string[];
-		}>
-	>;
+  export function searchByWorker(
+    baseUrl: string,
+    searchContext: string,
+    query: string,
+  ): Promise<
+    Array<{
+      document: {
+        u: string;
+        t: string;
+        h?: string;
+        s?: string;
+      };
+      tokens: string[];
+    }>
+  >;
 }


### PR DESCRIPTION
`develop`'s `test` workflow is red at `check_lint → yarn check-fmt` because 4 `.ts` files under `docs-website/` are not prettier-formatted. This skips `test_unit`/`test_e2e` and blocks **every** PR in the repo (including the dependabot major-bump PRs).

Ran `prettier --write` on exactly those 4 files. **Formatting-only, no logic changes.** After this, `prettier --check "**/*.ts"` is clean.

Unblocks the CI gate for #543 (nodemailer) and #544 (@nestjs/* 10→11).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Prettier formatting in `docs-website` so `check_lint → yarn check-fmt` passes and CI no longer skips tests. Formatting-only on four TypeScript files; no behavior changes.

- **Bug Fixes**
  - Ran `prettier --write` on `docusaurus.config.ts`, `sidebars.ts`, `src/theme.d.ts`, and `src/theme/SearchBar/types.d.ts`.
  - `prettier --check "**/*.ts"` is now clean, restoring `test_unit` and `test_e2e` in CI.

<sup>Written for commit 9f8a228dc256f3a12d56e77b6454fd3e1089a15c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-traduora/pull/546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

