### PR TITLE
fix(api): restore translation foreign keys on SQLite

### DIFF
--- a/api/src/migrations/1785664547143-restore-translation-foreign-keys.ts
+++ b/api/src/migrations/1785664547143-restore-translation-foreign-keys.ts
@@ -1,0 +1,104 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { config } from '../config';
+import { DbType } from '../utils/database-type-helper';
+
+export class RestoreTranslationForeignKeys1785664547143 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    switch (config.db.default.type) {
+      case DbType.POSTGRES:
+      case DbType.MYSQL:
+        // The foreign keys from the initial migration are still in place.
+        break;
+      case DbType.BETTER_SQLITE3:
+        // The table rebuilds in migrations 1542044660604 and 1543494409127
+        // recreated "translation" without the foreign keys declared in the
+        // initial migration, so deleting a term or a project locale stopped
+        // cascading and left orphaned translation rows behind (#492).
+        //
+        // "label_translations_translation" references "translation" with ON
+        // DELETE CASCADE, and PRAGMA foreign_keys cannot change inside a
+        // transaction, so dropping the table below may cascade and clear the
+        // label associations. They are backed up first and restored at the
+        // end, which keeps the rebuild correct whether or not foreign key
+        // enforcement is active while the migration runs.
+        await this.rebuildTranslationTable(queryRunner, true);
+        break;
+      default:
+        throw new Error(`Unknown DB type: ${config.db.default.type}`);
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    switch (config.db.default.type) {
+      case DbType.POSTGRES:
+      case DbType.MYSQL:
+        break;
+      case DbType.BETTER_SQLITE3:
+        await this.rebuildTranslationTable(queryRunner, false);
+        break;
+      default:
+        throw new Error(`Unknown DB type: ${config.db.default.type}`);
+    }
+  }
+
+  private async rebuildTranslationTable(queryRunner: QueryRunner, withForeignKeys: boolean): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "label_translations_backup" AS
+       SELECT "label_id", "translation_term_id", "translation_project_locale_id" FROM "label_translations_translation"`,
+    );
+
+    const foreignKeys = withForeignKeys
+      ? `,
+            FOREIGN KEY ("term_id") REFERENCES "term"("id") ON DELETE CASCADE,
+            FOREIGN KEY ("project_locale_id") REFERENCES "project_locale"("id") ON DELETE CASCADE`
+      : '';
+
+    await queryRunner.query(
+      `CREATE TABLE "translation_temp" (
+            "term_id" TEXT NOT NULL,
+            "project_locale_id" TEXT NOT NULL,
+            "value" TEXT NOT NULL,
+            "date_created" TEXT NOT NULL DEFAULT (datetime('now')),
+            "date_modified" TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY ("term_id", "project_locale_id")${foreignKeys}
+          )`,
+    );
+
+    // Copying only the rows whose term and project locale still exist drops
+    // the orphans accumulated while the foreign keys were missing.
+    await queryRunner.query(
+      `INSERT INTO "translation_temp" ("term_id", "project_locale_id", "value", "date_created", "date_modified")
+       SELECT "term_id", "project_locale_id", "value", "date_created", "date_modified"
+       FROM "translation"
+       WHERE "term_id" IN (SELECT "id" FROM "term")
+         AND "project_locale_id" IN (SELECT "id" FROM "project_locale")`,
+    );
+
+    await queryRunner.query(`DROP TABLE "translation"`);
+    await queryRunner.query(`ALTER TABLE "translation_temp" RENAME TO "translation"`);
+
+    await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_translation_term_id" ON "translation" ("term_id")`);
+    await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_translation_project_locale_id" ON "translation" ("project_locale_id")`);
+
+    // Restore the label associations for the translations that survived the
+    // rebuild. INSERT OR IGNORE covers the case where the drop above did not
+    // cascade and the association rows are still present.
+    await queryRunner.query(
+      `INSERT OR IGNORE INTO "label_translations_translation" ("label_id", "translation_term_id", "translation_project_locale_id")
+       SELECT "label_id", "translation_term_id", "translation_project_locale_id"
+       FROM "label_translations_backup"
+       WHERE ("translation_term_id", "translation_project_locale_id") IN
+         (SELECT "term_id", "project_locale_id" FROM "translation")`,
+    );
+
+    // If the drop did not cascade, associations pointing at purged orphan
+    // translations are still around and must go too.
+    await queryRunner.query(
+      `DELETE FROM "label_translations_translation"
+       WHERE ("translation_term_id", "translation_project_locale_id") NOT IN
+         (SELECT "term_id", "project_locale_id" FROM "translation")`,
+    );
+
+    await queryRunner.query(`DROP TABLE "label_translations_backup"`);
+  }
+}

--- a/api/test/term.e2e-spec.ts
+++ b/api/test/term.e2e-spec.ts
@@ -181,6 +181,75 @@ describe('TermController (e2e)', () => {
       });
   });
 
+  const countTranslationsForTerm = async (termId: string): Promise<number> => {
+    const row = await app
+      .get(Connection)
+      .createQueryBuilder()
+      .select('COUNT(*)', 'count')
+      .from('translation', 'translation')
+      .where('translation.term_id = :termId', { termId })
+      .getRawOne();
+    return Number(row.count);
+  };
+
+  const createTranslatedTerm = async (): Promise<string> => {
+    let termId = '';
+
+    await request(app.getHttpServer())
+      .post(`/api/v1/projects/${testProject.id}/terms`)
+      .set('Authorization', `Bearer ${testingUser.accessToken}`)
+      .send({
+        value: 'term.one',
+      })
+      .expect(201)
+      .expect(res => {
+        termId = res.body.data.id;
+      });
+
+    await request(app.getHttpServer())
+      .post(`/api/v1/projects/${testProject.id}/translations`)
+      .set('Authorization', `Bearer ${testingUser.accessToken}`)
+      .send({
+        code: 'de_DE',
+      })
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .patch(`/api/v1/projects/${testProject.id}/translations/de_DE`)
+      .set('Authorization', `Bearer ${testingUser.accessToken}`)
+      .send({
+        termId,
+        value: 'eins',
+      })
+      .expect(200);
+
+    return termId;
+  };
+
+  it('/api/v1/projects/:projectId/terms/:termId (DELETE) should also delete related translations', async () => {
+    const termId = await createTranslatedTerm();
+    expect(await countTranslationsForTerm(termId)).toEqual(1);
+
+    await request(app.getHttpServer())
+      .delete(`/api/v1/projects/${testProject.id}/terms/${termId}`)
+      .set('Authorization', `Bearer ${testingUser.accessToken}`)
+      .expect(204);
+
+    expect(await countTranslationsForTerm(termId)).toEqual(0);
+  });
+
+  it('/api/v1/projects/:projectId/translations/:localeCode (DELETE) should also delete related translations', async () => {
+    const termId = await createTranslatedTerm();
+    expect(await countTranslationsForTerm(termId)).toEqual(1);
+
+    await request(app.getHttpServer())
+      .delete(`/api/v1/projects/${testProject.id}/translations/de_DE`)
+      .set('Authorization', `Bearer ${testingUser.accessToken}`)
+      .expect(204);
+
+    expect(await countTranslationsForTerm(termId)).toEqual(0);
+  });
+
   it('/api/v1/projects/:projectId/terms should not access terms resource if not authenticated', async () => {
     let termId: string;
 


### PR DESCRIPTION
Fixes #492

**Root cause**

The initial migration created the SQLite translation table with two inline foreign keys, term_id and project_locale_id, both ON DELETE CASCADE. SQLite cannot alter constraints in place, so two later migrations rebuilt the table: 1542044660604 (composite primary key) and 1543494409127 (value column type). Both rebuilds recreated the table without any foreign key, and the second one is the final state. Since then, on SQLite (the default database type), deleting a term or a project locale does not cascade and leaves orphaned translation rows behind. That is what produced the 404 described here. #493 filters the orphans at read time, but they keep accumulating on every deletion. MySQL and Postgres are not affected, their migration branches never dropped the constraints.

**Fix**

A new migration rebuilds the translation table on SQLite with the two original ON DELETE CASCADE foreign keys and the existing indexes. The copy keeps only the rows whose term and project locale still exist, which purges the orphans accumulated while the constraints were missing. MySQL and Postgres branches are a no op.

**Tests**

A new e2e test creates a term, adds a locale, sets a translation value, deletes the term and asserts that no translation row remains. Without the new migration this test fails with one orphaned row, which reproduces the issue on develop. The full e2e suite (116 tests) and the unit suite (41 tests) pass. I also replayed the migration SQL against a database in the legacy state containing both orphan kinds, by term and by locale: the copy keeps only the valid rows, PRAGMA foreign_key_list shows both constraints restored, and a term deletion then cascades as expected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores ON DELETE CASCADE foreign keys on SQLite `translation` so deleting terms or project locales cascades and no orphans remain. Fixes #492; adds a migration that rebuilds the table and purges invalid rows. MySQL/Postgres are unaffected.

- **Bug Fixes**
  - Rebuilds SQLite `translation` with foreign keys to `term(id)` and `project_locale(id)`.
  - Copies only rows with valid parents; backs up and restores `label_translations_translation`, then removes invalid links.
  - Adds e2e tests confirming cascades on term and locale deletion.

- **Migration**
  - Run migrations; SQLite will rebuild the table and clean up data automatically.

<sup>Written for commit 474812d985f8a329d6a810a3ac384722945f5088. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-traduora/pull/551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

