### PR TITLE
fix(api): merge fallback export translations by term

### DIFF
--- a/api/src/controllers/exports.controller.ts
+++ b/api/src/controllers/exports.controller.ts
@@ -22,7 +22,6 @@ import { phpExporter } from '../formatters/php';
 import { ApiOAuth2, ApiTags, ApiOperation, ApiProduces, ApiResponse } from '@nestjs/swagger';
 import { androidXmlExporter } from '../formatters/android-xml';
 import { resXExporter } from '../formatters/resx';
-import { merge } from 'lodash';
 import { resolveColumnName } from '../utils/alias-helper';
 import { getLexicalOrderClause } from '../utils/database-type-helper';
 
@@ -129,9 +128,17 @@ export class ExportsController {
           translation: t.translations.length === 1 ? t.translations[0].value : '',
         }));
 
+        // Merge by term. The requested locale only contains the translated
+        // terms at this point, so a positional merge would pair unrelated
+        // terms and drop entries (#420).
+        const translated = new Map(data.translations.map(t => [t.term, t.translation]));
+
         const dataWithFallback: IntermediateTranslationFormat = {
           iso: query.locale,
-          translations: merge(fallbackTermsWithTranslationsMapped, data.translations),
+          translations: fallbackTermsWithTranslationsMapped.map(t => ({
+            term: t.term,
+            translation: translated.get(t.term) ?? t.translation,
+          })),
         };
 
         serialized = await this.dump(query.format, dataWithFallback);

--- a/api/test/export.e2e-spec.ts
+++ b/api/test/export.e2e-spec.ts
@@ -111,6 +111,45 @@ describe('ExportController (e2e)', () => {
       });
   });
 
+  it('/api/v1/projects/:projectId/exports (GET) should fill untranslated terms from the fallback locale', async () => {
+    const authorized = (req: request.Test) => req.set('Authorization', `Bearer ${testingUser.accessToken}`);
+
+    const createTerm = async (value: string): Promise<string> => {
+      const res = await authorized(request(app.getHttpServer()).post(`/api/v1/projects/${testProject.id}/terms`))
+        .send({ value })
+        .expect(201);
+      return res.body.data.id;
+    };
+
+    const translate = (localeCode: string, termId: string, value: string) =>
+      authorized(request(app.getHttpServer()).patch(`/api/v1/projects/${testProject.id}/translations/${localeCode}`))
+        .send({ termId, value })
+        .expect(200);
+
+    const exportLocale = async (params: string): Promise<any> => {
+      const res = await authorized(request(app.getHttpServer()).get(`/api/v1/projects/${testProject.id}/exports?${params}`)).expect(200);
+      return JSON.parse(Buffer.from(res.body).toString('utf-8'));
+    };
+
+    const nestedTermId = await createTerm('group.term');
+    await authorized(request(app.getHttpServer()).post(`/api/v1/projects/${testProject.id}/translations`))
+      .send({ code: 'nl' })
+      .expect(201);
+    await translate('nl', termTwoId, 'twee');
+    await translate('de_DE', nestedTermId, 'gruppe');
+
+    const flat = await exportLocale('locale=nl&format=jsonflat&fallbackLocale=de_DE');
+    expect(Object.keys(flat)).toEqual(['group.term', 'term.one', 'term.two']);
+    expect(flat['group.term']).toEqual('gruppe');
+    expect(flat['term.one']).toEqual('eins');
+    expect(flat['term.two']).toEqual('twee');
+
+    const nested = await exportLocale('locale=nl&format=jsonnested&fallbackLocale=de_DE');
+    expect(nested.group.term).toEqual('gruppe');
+    expect(nested.term.one).toEqual('eins');
+    expect(nested.term.two).toEqual('twee');
+  });
+
   it('/api/v1/projects/:projectId/exports (GET) should export terms in lexical order', async () => {
     const input = ['app.login', 'should be before base terms', '1 goes first', 'app.logout', 'app.exit', 'menu.start', 'a term', '2 goes second'];
 


### PR DESCRIPTION
Fixes #420

**Root cause**

The fallback export path merges the fallback locale list and the requested locale list with lodash `merge`, which merges arrays by index. At that point the requested locale list has been filtered down to translated terms only, so the two arrays are not aligned: the positional merge pairs unrelated terms, drops entries and duplicates others in the resulting file. A quick illustration with three fallback terms and one translated term:

```js
merge(
  [{ term: 'a', translation: 'fa' }, { term: 'b', translation: 'fb' }, { term: 'c', translation: 'fc' }],
  [{ term: 'c', translation: 'tc' }],
);
// [{ term: 'c', translation: 'tc' }, { term: 'b', translation: 'fb' }, { term: 'c', translation: 'fc' }]
// term 'a' is gone and term 'c' appears twice
```

**Fix**

Merge by term instead: build a map of the translations the requested locale actually has, then walk the full fallback list and override where a translation exists. Every term from the fallback list is kept, lexical order is preserved, and the lodash import is no longer needed.

**Tests**

A new e2e test creates a locale that translates only one of the two terms and exports it with the fully translated locale as fallback. On develop the export contains a single key with the fallback value instead of two keys, which reproduces the report. With the fix the export contains both terms, the translated one with its own value and the untranslated one with the fallback value. The full e2e suite passes on SQLite (116 tests) and on Postgres 16 (116 tests), and the unit suite passes (41 tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix fallback export by merging translations by term instead of by array position, preserving all keys and lexical order across flat and nested formats. Prevents missing and duplicated entries when exporting a partially translated locale. Fixes #420.

- **Bug Fixes**
  - Replaced `lodash` positional merge with a term-indexed overlay of the requested locale onto the fallback list.
  - Added e2e tests for `jsonflat` and `jsonnested`, covering nested terms and confirming untranslated keys use the fallback while translated keys remain.

<sup>Written for commit b48805d4549c79638f82bed69f32c5fa50617296. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-traduora/pull/552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

