### PR TITLE
fix(api): accept padded CSV imports and surface parse errors

### DIFF
--- a/api/src/controllers/import.controller.ts
+++ b/api/src/controllers/import.controller.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Controller,
   HttpCode,
+  HttpException,
   HttpStatus,
   NotFoundException,
   Param,
@@ -138,9 +139,11 @@ export class ImportController {
     } catch (error) {
       if (error instanceof PaymentRequiredException) {
         throw new PaymentRequiredException('request would exceed plan limit');
-      } else {
-        throw new NotFoundException();
       }
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new NotFoundException();
     }
   }
 
@@ -220,7 +223,8 @@ export class ImportController {
           throw new Error('Export format not implemented');
       }
     } catch (err) {
-      throw new BadRequestException('Malformed import file');
+      const detail = err instanceof Error && err.message ? `: ${err.message}` : '';
+      throw new BadRequestException(`Malformed import file${detail}`);
     }
   }
 }

--- a/api/src/formatters/csv.spec.ts
+++ b/api/src/formatters/csv.spec.ts
@@ -7,13 +7,24 @@ test('should parse csv files', async () => {
   expect(result).toEqual(simpleFormatFixture);
 });
 
+test('should tolerate trailing empty columns from spreadsheet exports', async () => {
+  const input = 'term.one,translation one,,,\nterm.two,translation two,';
+  const result = await csvParser(input);
+  expect(result).toEqual({
+    translations: [
+      { term: 'term.one', translation: 'translation one' },
+      { term: 'term.two', translation: 'translation two' },
+    ],
+  });
+});
+
 test('should fail if file is malformed, invalid or empty', async () => {
   const inputs = [
     'term.one, translation\nterm.two in new line and no second column',
     'term.one',
     'term.one: translation',
-    'term.one, translation,',
     'term.one, val1, val2',
+    'term.one, translation, extra data',
   ];
 
   expect.assertions(inputs.length);
@@ -21,6 +32,18 @@ test('should fail if file is malformed, invalid or empty', async () => {
   for (const input of inputs) {
     await expect(csvParser(input)).rejects.toBeDefined();
   }
+});
+
+test('should explain that values containing commas must be quoted', async () => {
+  await expect(csvParser('term.one,an unquoted, comma')).rejects.toThrow(
+    'Line 1 has content after the translation column. Values containing commas must be quoted.',
+  );
+});
+
+test('should report source line numbers even when blank lines are skipped', async () => {
+  await expect(csvParser('term.one,ok\n\nterm.two,an unquoted, comma')).rejects.toThrow(
+    'Line 3 has content after the translation column. Values containing commas must be quoted.',
+  );
 });
 
 test('should export csv files', async () => {

--- a/api/src/formatters/csv.ts
+++ b/api/src/formatters/csv.ts
@@ -25,10 +25,25 @@ export const csvParser: Parser = async (data: string) => {
   const reader = parse(data, {
     trim: true,
     skip_empty_lines: true,
-    columns: ['term', 'translation'],
+    relax_column_count: true,
+    info: true,
   });
 
-  const translations = await streamAsPromise(reader);
+  const rows: Array<{ record: string[]; info: { lines: number } }> = await streamAsPromise(reader);
+
+  // Spreadsheet exports commonly pad rows with trailing empty columns, so
+  // those are tolerated. Extra columns with content are still rejected, since
+  // they signal an unquoted delimiter and dropping them would corrupt the
+  // translation (#379).
+  const translations = rows.map(({ record, info }) => {
+    if (record.length < 2) {
+      throw new Error(`Expected a term and a translation column on line ${info.lines}, found ${record.length} column`);
+    }
+    if (record.slice(2).some(field => field !== '')) {
+      throw new Error(`Line ${info.lines} has content after the translation column. Values containing commas must be quoted.`);
+    }
+    return { term: record[0], translation: record[1] };
+  });
 
   return {
     translations,

--- a/api/test/import.e2e-spec.ts
+++ b/api/test/import.e2e-spec.ts
@@ -388,6 +388,33 @@ describe('ImportController (e2e)', () => {
       });
   });
 
+  it('/api/v1/projects/:projectId/imports (POST) should import CSV files with trailing empty columns', async () => {
+    const csvWithTrailingColumns = 'term.csv.one,first translation,,,\nterm.csv.two,second translation,,,\n';
+
+    await request(app.getHttpServer())
+      .post(`/api/v1/projects/${testProject.id}/imports?locale=en&format=csv`)
+      .set('Authorization', `Bearer ${testingUser.accessToken}`)
+      .attach('file', Buffer.from(csvWithTrailingColumns), 'file')
+      .expect(200)
+      .expect(res => {
+        expect(res.body.data.terms.added).toEqual(2);
+        expect(res.body.data.translations.upserted).toEqual(2);
+      });
+  });
+
+  it('/api/v1/projects/:projectId/imports (POST) should reject malformed CSV files with a bad request error', async () => {
+    const csvWithUnquotedDelimiter = 'term.csv.one,an unquoted, comma\n';
+
+    await request(app.getHttpServer())
+      .post(`/api/v1/projects/${testProject.id}/imports?locale=en&format=csv`)
+      .set('Authorization', `Bearer ${testingUser.accessToken}`)
+      .attach('file', Buffer.from(csvWithUnquotedDelimiter), 'file')
+      .expect(400)
+      .expect(res => {
+        expect(res.body.error.code).toEqual('BadRequest');
+      });
+  });
+
   it('/api/v1/projects/:projectId/imports (POST) should not import if params are missing or invalid', async () => {
     // Missing payload
     await request(app.getHttpServer())


### PR DESCRIPTION
Fixes #379

**Root cause, two layers**

The CSV parser required every row to have exactly two columns. Spreadsheet exports routinely pad rows with trailing empty columns, so a file like the sample attached to #379 (`start,Start,,,`) failed on its very first row. On top of that, the import endpoint caught every error and replaced it with a bare `NotFoundException`, swallowing the `Malformed import file` message the parse helper had produced. The reporter therefore saw a mute 404 and the UI did nothing, which made the failure look locale related when it was not.

**Fix**

* The CSV parser now tolerates trailing empty columns. Rows with actual content beyond the translation column are still rejected, because that pattern comes from an unquoted comma inside the translation, and silently dropping the extra fields would corrupt the imported value. The error now names the offending row and explains that values containing commas must be quoted. Running the exact sample file from the issue through the parser now yields: `Row 37 has content after the translation column. Values containing commas must be quoted.`
* The import endpoint lets `HttpException`s pass through instead of converting them to 404, so parse failures surface as a 400 with the parser detail attached. The existing payment limit behavior is unchanged.

Note on expected behavior: the previous unit spec listed `term.one, translation,` among the inputs that must be rejected. This PR deliberately moves that shape to the accepted side, since it is what spreadsheet exports produce and no information is lost by ignoring empty padding.

**Tests**

New unit tests cover the padded rows and the quoting error message, and the malformed inputs list still passes for the genuinely broken shapes. New e2e tests import a padded CSV successfully and assert that a CSV with an unquoted comma now returns 400 instead of 404. Reverting the source changes makes exactly those four tests fail. The full e2e suite passes on SQLite (117 tests) and Postgres 16 (117 tests), and the unit suite passes (43 tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept CSV imports with trailing empty columns and return parser errors as 400 with clear, line-specific messages instead of 404. Fixes #379.

- **Bug Fixes**
  - CSV parser tolerates padded rows; rejects any non-empty field after the translation column and reports the source line with a note to quote commas.
  - Import endpoint rethrows `HttpException`s; malformed files now return 400 with parser details. Payment limit behavior unchanged.
  - Added unit and e2e tests for padded rows, line-numbered errors, and 400 propagation.

<sup>Written for commit 0ee193feb61f5eccd1d1f51171e6606e95ea3222. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-traduora/pull/553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

